### PR TITLE
Add support for Python 3.8

### DIFF
--- a/requirements_3.8.txt
+++ b/requirements_3.8.txt
@@ -1,0 +1,10 @@
+numpy==1.19.5
+opencv-python==4.1.2.30
+scipy==1.4.1
+tensorflow==2.5.0
+colorama==0.4.3
+tqdm==4.47.0
+ffmpeg-python==0.2.0
+Pillow==7.2.0
+scikit-image==0.17.2
+h5py==3.1.0

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -15,6 +15,14 @@ fi
 
 source .dfl/env/bin/activate
 
-pip install -r requirements.txt
+version=$(python -V | cut -f 2 -d ' ' | cut -f 1,2 -d .)
+reqs_file='requirements.txt'
+
+if [[ ! -z "$version" && -f "requirements_$version.txt" ]]; then
+  reqs_file="requirements_$version.txt"
+fi
+
+echo "Using $reqs_file"
+pip install -r $reqs_file
 
 echo "Done."


### PR DESCRIPTION
## Overview

Expanding `0_setup.sh` script to support Python version specific `requirements.txt` files and adding support for Python 3.8.
The script will check the Python version installed and will use corresponding `requirements.txt` file if it exists. The default `requirements.txt` still corresponds to version `3.6`.