### PR TITLE
Make default requirements.txt work for Python 3.7 and 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy==1.17.0
-opencv-python==4.1.0.25
+numpy==1.19.5
+opencv-python==4.1.2.30
 scipy==1.4.1
-tensorflow==1.15.2
+tensorflow==2.5.0
 colorama==0.4.3
 tqdm==4.47.0
 ffmpeg-python==0.2.0
 Pillow==7.2.0
 scikit-image==0.17.2
-h5py==2.10.0
+h5py==3.1.0

--- a/requirements_3.6.txt
+++ b/requirements_3.6.txt
@@ -1,10 +1,10 @@
-numpy==1.19.5
-opencv-python==4.1.2.30
+numpy==1.17.0
+opencv-python==4.1.0.25
 scipy==1.4.1
-tensorflow==2.5.0
+tensorflow==1.15.2
 colorama==0.4.3
 tqdm==4.47.0
 ffmpeg-python==0.2.0
 Pillow==7.2.0
 scikit-image==0.17.2
-h5py==3.1.0
+h5py==2.10.0


### PR DESCRIPTION
## Overview

Here we're renaming current default `requirements.txt -> requirements_3.6.txt` as it was initially created for Python `3.6`. And we're renaming `requirements_3.8.txt -> requirements.txt` to make it a default which works for both Python `3.7` and `3.8`.

Addressing issue https://github.com/chychkan/DeepFaceLab_MacOS/issues/6