### PR TITLE
Upgrade Pillow to 8.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tensorflow==2.5.0
 colorama==0.4.3
 tqdm==4.47.0
 ffmpeg-python==0.2.0
-Pillow==7.2.0
+Pillow==8.2.0
 scikit-image==0.17.2
 h5py==3.1.0
 PyQt5==5.15.4

--- a/requirements_3.6.txt
+++ b/requirements_3.6.txt
@@ -5,7 +5,7 @@ tensorflow==1.15.2
 colorama==0.4.3
 tqdm==4.47.0
 ffmpeg-python==0.2.0
-Pillow==7.2.0
+Pillow==8.2.0
 scikit-image==0.17.2
 h5py==2.10.0
 PyQt5==5.15.4

--- a/requirements_3.9.txt
+++ b/requirements_3.9.txt
@@ -5,7 +5,7 @@ tensorflow==2.5.0
 colorama==0.4.3
 tqdm==4.47.0
 ffmpeg-python==0.2.0
-Pillow==7.2.0
+Pillow==8.2.0
 scikit-image==0.18.0
 h5py==3.1.0
 PyQt5==5.15.4


### PR DESCRIPTION
Upgrading the dependency to eliminate [multiple security vulnerabilities](https://www.cvedetails.com/vulnerability-list/vendor_id-10210/product_id-27460/Python-Pillow.html) in the Pillow package.