### PR TITLE
Set flag in all scripts to abort execution if command fails

### DIFF
--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 cd "$(dirname $0)/.."
 
+set -e
+
 mkdir -p .dfl
 mkdir -p workspace
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -2,3 +2,5 @@ DFL_MAIN=.dfl/DeepFaceLab/main.py
 WORKSPACE=workspace
 
 source .dfl/env/bin/activate
+
+set -e


### PR DESCRIPTION
This will fix the GitHub Action that currently passes even when the dependencies cannot be resolved (like in [this one](https://github.com/chychkan/DeepFaceLab_MacOS/runs/3416029698?check_suite_focus=true)).