### PR TITLE
Upgrade opencv-contrib-python-headless to 4.5.1.48 for Python 3.9

### DIFF
--- a/requirements_3.9.txt
+++ b/requirements_3.9.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
-opencv-contrib-python-headless==4.4.0.46
+opencv-contrib-python-headless==4.5.1.48
 scipy==1.7.1
 tensorflow==2.6.0
 colorama==0.4.4


### PR DESCRIPTION
Addressing https://github.com/chychkan/DeepFaceLab_MacOS/issues/44