### PR TITLE
Add support for Apple M1 laptops

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project provides scripts inspired by [DeepFaceLab_Linux](https://github.com
 
 You'll need `git`, `ffmpeg`, `python3` and python module `virtualenv` available to be able to execute these scripts. The scripts will create a virtual env sandbox and will install all necessary dependencies there, so your main installation of `python3` will be left intact.
 
+## NOTE: Apple M1 chip
+
+Currently there's limited support for Apple M1 laptops. You can do model training, but the XSeg editor currently does not work (the DeepFaceLab codebase is not compatible with PyQt6).
+
 ## Setup
 
 **Tools**
@@ -13,6 +17,9 @@ Make sure you have installed:
 - [FFmpeg](https://ffmpeg.org/) (check with `ffmpeg -version`)
 - [Python 3](https://www.python.org/) (check with `python3 --version`)
 - [Virtualenv](https://github.com/pypa/virtualenv) (check with `virtualenv --version`)
+
+For **Apple M1** laptops you also need [hdf5](https://formulae.brew.sh/formula/hdf5) lib installed.
+Check if you have it with `brew ls --versions hdf5`. Install it with `brew install hdf5`.
 
 **Clone and setup**
 

--- a/requirements_3.9_arm64.txt
+++ b/requirements_3.9_arm64.txt
@@ -8,7 +8,6 @@ cython==0.29.26
 ffmpeg-python==0.2.0
 Pillow==8.4.0
 scikit-image==0.19.0
-numpy==1.21.4
 scipy==1.7.3
 tensorflow-macos==2.7.0
 PyQt6==6.0.3

--- a/requirements_3.9_arm64.txt
+++ b/requirements_3.9_arm64.txt
@@ -1,0 +1,14 @@
+numpy==1.21.4
+opencv-python==4.5.3.56
+numexpr==2.8.1
+h5py==3.1.0
+tqdm==4.62.3
+colorama==0.4.4
+cython==0.29.26
+ffmpeg-python==0.2.0
+Pillow==8.4.0
+scikit-image==0.19.0
+numpy==1.21.4
+scipy==1.7.3
+tensorflow-macos==2.7.0
+PyQt6==6.0.3

--- a/requirements_3.9_arm64.txt
+++ b/requirements_3.9_arm64.txt
@@ -1,5 +1,5 @@
 numpy==1.21.4
-opencv-python==4.5.3.56
+opencv-python==4.5.5.62
 numexpr==2.8.1
 h5py==3.1.0
 tqdm==4.62.3
@@ -7,7 +7,7 @@ colorama==0.4.4
 cython==0.29.26
 ffmpeg-python==0.2.0
 Pillow==8.4.0
-scikit-image==0.19.0
-scipy==1.7.3
+scikit-image==0.19.1
+scipy==1.8.0
 tensorflow-macos==2.7.0
-PyQt6==6.0.3
+PyQt6==6.2.3

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -10,13 +10,13 @@ is_arm64() {
   [ "$(uname -m)" == "arm64" ]
 }
 
-[ is_arm64 ] && echo "Running on Apple M1 chip"
+is_arm64 && echo "Running on Apple M1 chip"
 
 if [ ! -d .dfl/DeepFaceLab ]; then
   echo "Cloning DeepFaceLab"
   git clone --no-single-branch --depth 1 "https://github.com/chychkan/DeepFaceLab.git" .dfl/DeepFaceLab
 
-  if [ is_arm64 ]; then
+  if is_arm64; then
     (cd .dfl/DeepFaceLab; git checkout support-arm64)
   fi
 fi
@@ -38,7 +38,7 @@ if [[ ! -z "$version" && -f "requirements_$version.txt" ]]; then
 fi
 
 architecture_suffix=''
-if [ is_arm64 ] && [ -f "requirements${version_suffix}_arm64.txt" ]; then
+if is_arm64 && [ -f "requirements${version_suffix}_arm64.txt" ]; then
   architecture_suffix="_arm64"
 fi
 
@@ -46,7 +46,7 @@ reqs_file="requirements${version_suffix}${architecture_suffix}.txt"
 
 echo "Using $reqs_file for $(python -V)"
 
-if [ is_arm64 ]; then
+if is_arm64; then
   if [[ -z "$(brew ls --versions hdf5)" ]]; then
     echo "ERROR: HDF5 needs to be installed to run DeepFaceLab on M1 chip."
     echo "You can install it with 'brew install hdf5'. For more details, see https://formulae.brew.sh/formula/hdf5"

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -48,10 +48,13 @@ if [[ ! -z "$architecture" ]]; then
   fi
 
   cython_pkg="$(cat $reqs_file | grep -E 'cython==.+')"
-  pip --no-cache-dir install $cython_pkg
+  pip --no-cache-dir install "$cython_pkg"
+
+  numpy_pkg="$(cat $reqs_file | grep -E 'numpy==.+')"
+  pip install "$numpy_pkg"
 
   h5py_pkg="$(cat $reqs_file | grep -E 'h5py==.+')"
-  HDF5_DIR="$(brew --prefix hdf5)" pip --no-cache-dir install --no-build-isolation $h5py_pkg
+  HDF5_DIR="$(brew --prefix hdf5)" pip --no-cache-dir install --no-build-isolation "$h5py_pkg"
 fi
 
 pip --no-cache-dir install -r $reqs_file

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -13,10 +13,10 @@ fi
 
 if [ ! -d .dfl/DeepFaceLab ]; then
   echo "Cloning DeepFaceLab"
-  git clone --depth 1 "https://github.com/chychkan/DeepFaceLab.git" .dfl/DeepFaceLab
+  git clone --no-single-branch --depth 1 "https://github.com/chychkan/DeepFaceLab.git" .dfl/DeepFaceLab
 
   if [ "$architecture" == "arm64" ]; then
-    git checkout support-arm64
+    (cd .dfl/DeepFaceLab; git checkout support-arm64)
   fi
 fi
 
@@ -35,7 +35,7 @@ if [[ ! -z "$version" && -f "requirements_$version.txt" ]]; then
 fi
 
 architecture_suffix=''
-if [ "$architecture" == "arm64" && -f "requirements${version_suffix}_arm64.txt" ]; then
+if [ "$architecture" == "arm64" ] && [ -f "requirements${version_suffix}_arm64.txt" ]; then
   architecture_suffix="_arm64"
 fi
 

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -6,9 +6,18 @@ set -e
 mkdir -p .dfl
 mkdir -p workspace
 
+architecture=''
+if [[ ! -z "$(uname -a | grep -oE ' arm64$')" ]]; then
+  architecture='arm64'
+fi
+
 if [ ! -d .dfl/DeepFaceLab ]; then
   echo "Cloning DeepFaceLab"
-  git clone --depth 1 "https://github.com/iperov/DeepFaceLab.git" .dfl/DeepFaceLab
+  git clone --depth 1 "https://github.com/chychkan/DeepFaceLab.git" .dfl/DeepFaceLab
+
+  if [ "$architecture" == "arm64" ]; then
+    git checkout support-arm64
+  fi
 fi
 
 if [ ! -d .dfl/env ]; then
@@ -25,13 +34,8 @@ if [[ ! -z "$version" && -f "requirements_$version.txt" ]]; then
   version_suffix="_$version"
 fi
 
-architecture=''
-if [[ ! -z "$(uname -a | grep -oE ' arm64$')" && -f "requirements${version_suffix}_arm64.txt" ]]; then
-  architecture='arm64'
-fi
-
 architecture_suffix=''
-if [[ ! -z "$architecture" ]]; then
+if [ "$architecture" == "arm64" && -f "requirements${version_suffix}_arm64.txt" ]; then
   architecture_suffix="_arm64"
 fi
 

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -6,16 +6,17 @@ set -e
 mkdir -p .dfl
 mkdir -p workspace
 
-architecture=''
-if [[ ! -z "$(uname -a | grep -oE ' arm64$')" ]]; then
-  architecture='arm64'
-fi
+is_arm64() {
+  [ "$(uname -m)" == "arm64" ]
+}
+
+[ is_arm64 ] && echo "Running on Apple M1 chip"
 
 if [ ! -d .dfl/DeepFaceLab ]; then
   echo "Cloning DeepFaceLab"
   git clone --no-single-branch --depth 1 "https://github.com/chychkan/DeepFaceLab.git" .dfl/DeepFaceLab
 
-  if [ "$architecture" == "arm64" ]; then
+  if [ is_arm64 ]; then
     (cd .dfl/DeepFaceLab; git checkout support-arm64)
   fi
 fi
@@ -26,6 +27,8 @@ fi
 
 source .dfl/env/bin/activate
 
+python -m pip install --upgrade pip
+
 version=$(python -V | cut -f 2 -d ' ' | cut -f 1,2 -d .)
 reqs_file='requirements.txt'
 
@@ -35,7 +38,7 @@ if [[ ! -z "$version" && -f "requirements_$version.txt" ]]; then
 fi
 
 architecture_suffix=''
-if [ "$architecture" == "arm64" ] && [ -f "requirements${version_suffix}_arm64.txt" ]; then
+if [ is_arm64 ] && [ -f "requirements${version_suffix}_arm64.txt" ]; then
   architecture_suffix="_arm64"
 fi
 
@@ -43,7 +46,7 @@ reqs_file="requirements${version_suffix}${architecture_suffix}.txt"
 
 echo "Using $reqs_file for $(python -V)"
 
-if [[ ! -z "$architecture" ]]; then
+if [ is_arm64 ]; then
   if [[ -z "$(brew ls --versions hdf5)" ]]; then
     echo "ERROR: HDF5 needs to be installed to run DeepFaceLab on M1 chip."
     echo "You can install it with 'brew install hdf5'. For more details, see https://formulae.brew.sh/formula/hdf5"

--- a/scripts/0_setup.sh
+++ b/scripts/0_setup.sh
@@ -20,11 +20,40 @@ source .dfl/env/bin/activate
 version=$(python -V | cut -f 2 -d ' ' | cut -f 1,2 -d .)
 reqs_file='requirements.txt'
 
+version_suffix=''
 if [[ ! -z "$version" && -f "requirements_$version.txt" ]]; then
-  reqs_file="requirements_$version.txt"
+  version_suffix="_$version"
 fi
 
+architecture=''
+if [[ ! -z "$(uname -a | grep -oE ' arm64$')" && -f "requirements${version_suffix}_arm64.txt" ]]; then
+  architecture='arm64'
+fi
+
+architecture_suffix=''
+if [[ ! -z "$architecture" ]]; then
+  architecture_suffix="_arm64"
+fi
+
+reqs_file="requirements${version_suffix}${architecture_suffix}.txt"
+
 echo "Using $reqs_file for $(python -V)"
-pip install -r $reqs_file
+
+if [[ ! -z "$architecture" ]]; then
+  if [[ -z "$(brew ls --versions hdf5)" ]]; then
+    echo "ERROR: HDF5 needs to be installed to run DeepFaceLab on M1 chip."
+    echo "You can install it with 'brew install hdf5'. For more details, see https://formulae.brew.sh/formula/hdf5"
+    echo "Once it is installed, run ./scripts/0_setup.sh again"
+    exit 1
+  fi
+
+  cython_pkg="$(cat $reqs_file | grep -E 'cython==.+')"
+  pip --no-cache-dir install $cython_pkg
+
+  h5py_pkg="$(cat $reqs_file | grep -E 'h5py==.+')"
+  HDF5_DIR="$(brew --prefix hdf5)" pip --no-cache-dir install --no-build-isolation $h5py_pkg
+fi
+
+pip --no-cache-dir install -r $reqs_file
 
 echo "Done."


### PR DESCRIPTION
```
ERROR: Command errored out with exit status 1:
   command: /Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/bin/python /Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /var/folders/vl/xx410_4535l502jxllmhw1vh0000gn/T/tmp1idoyyad
       cwd: /private/var/folders/vl/xx410_4535l502jxllmhw1vh0000gn/T/pip-install-aqwib_cp/h5py_3df0f4459768426394baa18721ba291c
  Complete output (107 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.macosx-12-arm64-3.9
  creating build/lib.macosx-12-arm64-3.9/h5py
  copying h5py/h5py_warnings.py -> build/lib.macosx-12-arm64-3.9/h5py
  copying h5py/version.py -> build/lib.macosx-12-arm64-3.9/h5py
  copying h5py/__init__.py -> build/lib.macosx-12-arm64-3.9/h5py
  copying h5py/ipy_completer.py -> build/lib.macosx-12-arm64-3.9/h5py
  creating build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/files.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/compat.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/__init__.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/selections.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/dataset.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/vds.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/selections2.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/group.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/datatype.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/attrs.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/dims.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/base.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  copying h5py/_hl/filters.py -> build/lib.macosx-12-arm64-3.9/h5py/_hl
  creating build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_dimension_scales.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_attribute_create.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_file_image.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/conftest.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_h5d_direct_chunk.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_h5f.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_dataset_getitem.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_group.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_errors.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_dataset_swmr.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_slicing.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_h5pl.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_attrs.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/__init__.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_attrs_data.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_h5t.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_big_endian_file.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_h5p.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_dims_dimensionproxy.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_datatype.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/common.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_dataset.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_file.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_selections.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_dtype.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_h5.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_file2.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_completions.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_filters.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_base.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  copying h5py/tests/test_objects.py -> build/lib.macosx-12-arm64-3.9/h5py/tests
  creating build/lib.macosx-12-arm64-3.9/h5py/tests/data_files
  copying h5py/tests/data_files/__init__.py -> build/lib.macosx-12-arm64-3.9/h5py/tests/data_files
  creating build/lib.macosx-12-arm64-3.9/h5py/tests/test_vds
  copying h5py/tests/test_vds/test_highlevel_vds.py -> build/lib.macosx-12-arm64-3.9/h5py/tests/test_vds
  copying h5py/tests/test_vds/test_virtual_source.py -> build/lib.macosx-12-arm64-3.9/h5py/tests/test_vds
  copying h5py/tests/test_vds/__init__.py -> build/lib.macosx-12-arm64-3.9/h5py/tests/test_vds
  copying h5py/tests/test_vds/test_lowlevel_vds.py -> build/lib.macosx-12-arm64-3.9/h5py/tests/test_vds
  copying h5py/tests/data_files/vlen_string_s390x.h5 -> build/lib.macosx-12-arm64-3.9/h5py/tests/data_files
  copying h5py/tests/data_files/vlen_string_dset_utc.h5 -> build/lib.macosx-12-arm64-3.9/h5py/tests/data_files
  copying h5py/tests/data_files/vlen_string_dset.h5 -> build/lib.macosx-12-arm64-3.9/h5py/tests/data_files
  running build_ext
  Traceback (most recent call last):
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 261, in build_wheel
      return _build_backend().build_wheel(wheel_directory, config_settings,
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/build_meta.py", line 230, in build_wheel
      return self._build_with_temp_dir(['bdist_wheel'], '.whl',
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/build_meta.py", line 215, in _build_with_temp_dir
      self.run_setup()
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 158, in <module>
      setup(
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/__init__.py", line 155, in setup
      return distutils.core.setup(**attrs)
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 148, in setup
      return run_commands(dist)
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 163, in run_commands
      dist.run_commands()
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 967, in run_commands
      self.run_command(cmd)
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
      cmd_obj.run()
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/wheel/bdist_wheel.py", line 299, in run
      self.run_command('build')
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
      cmd_obj.run()
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/command/build.py", line 135, in run
      self.run_command(cmd_name)
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/Users/alex/Downloads/DeepFaceLab_MacOS-add-arm64-support/.dfl/env/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
      cmd_obj.run()
    File "/private/var/folders/vl/xx410_4535l502jxllmhw1vh0000gn/T/pip-install-aqwib_cp/h5py_3df0f4459768426394baa18721ba291c/setup_build.py", line 123, in run
      import numpy
  ModuleNotFoundError: No module named 'numpy'
  ----------------------------------------
  ERROR: Failed building wheel for h5py
Failed to build h5py
ERROR: Could not build wheels for h5py, which is required to install pyproject.toml-based projects
```